### PR TITLE
added timestamp to url to invalidate caches in clients when files have changed

### DIFF
--- a/albumart.c
+++ b/albumart.c
@@ -170,6 +170,7 @@ check_embedded_art(const char *path, uint8_t *image_data, int image_size)
 	static unsigned int last_hash = 0;
 	static int last_success = 0;
 	unsigned int hash;
+	DPRINTF(E_DEBUG, L_METADATA, " checking embedded art: '%s' = %p\n", path, image_data);
 
 	if( !image_data || !image_size || !path )
 	{
@@ -271,6 +272,7 @@ check_for_album_file(const char *path)
 	const char *dir;
 	struct stat st;
 	int ret;
+	DPRINTF(E_DEBUG, L_METADATA, " checking album art file: '%s'\n", path);
 
 	if( stat(path, &st) != 0 )
 		return NULL;
@@ -286,6 +288,7 @@ check_for_album_file(const char *path)
 	/* First look for file-specific cover art */
 	snprintf(file, sizeof(file), "%s.cover.jpg", path);
 	ret = access(file, R_OK);
+	DPRINTF(E_DEBUG, L_METADATA, " 	 file: '%s' = %i\n", file, ret);
 	if( ret != 0 )
 	{
 		strncpyt(file, path, sizeof(file));
@@ -294,6 +297,7 @@ check_for_album_file(const char *path)
 		{
 			strcpy(p, ".jpg");
 			ret = access(file, R_OK);
+			DPRINTF(E_DEBUG, L_METADATA, " 	 file: '%s' = %i\n", file, ret);
 		}
 		if( ret != 0 )
 		{
@@ -303,6 +307,7 @@ check_for_album_file(const char *path)
 				memmove(p+2, p+1, file+MAXPATHLEN-p-2);
 				p[1] = '.';
 				ret = access(file, R_OK);
+				DPRINTF(E_DEBUG, L_METADATA, " 	 file: '%s' = %i\n", file, ret);
 			}
 		}
 	}
@@ -320,7 +325,9 @@ check_dir:
 	for( album_art_name = album_art_names; album_art_name; album_art_name = album_art_name->next )
 	{
 		snprintf(file, sizeof(file), "%s/%s", dir, album_art_name->name);
-		if( access(file, R_OK) == 0 )
+		ret = access(file, R_OK);
+		DPRINTF(E_DEBUG, L_METADATA, " 	 file: '%s' = %i\n", file, ret);
+		if (ret == 0 )
 		{
 			if( art_cache_exists(file, &art_file) )
 			{

--- a/metadata.c
+++ b/metadata.c
@@ -1497,10 +1497,20 @@ video_no_dlna:
 
 	strcpy(nfo, path);
 	ext = strrchr(nfo, '.');
+	DPRINTF(E_DEBUG, L_METADATA, " nfo extension: '%s' [%s]\n", ext, path);
+
 	if( ext )
 	{
 		strcpy(ext+1, "nfo");
-		if( access(nfo, F_OK) == 0 )
+		int canAccess = access(nfo, F_OK);
+		DPRINTF(E_DEBUG, L_METADATA, " nfo text: '%s' = %i\n", nfo, canAccess);
+		if(canAccess != 0 )
+		{
+			strcpy(ext+1, "xml");
+			canAccess = access(nfo, F_OK);
+			DPRINTF(E_DEBUG, L_METADATA, " nfo text: '%s' = %i\n", nfo, canAccess);
+		}
+		if (canAccess == 0)
 		{
 			parse_nfo(nfo, &m);
 		}

--- a/upnpsoap.c
+++ b/upnpsoap.c
@@ -761,7 +761,10 @@ object_exists(const char *object)
 	return (ret > 0);
 }
 
-#define COLUMNS "o.DETAIL_ID, o.CLASS," \
+// using o.DETAIL_ID || '_' || strfttime('%%s',d.DATE) will generate IDs like 123_234234234
+// these IDs are distinct as soon as a rescan happens, invalidating possible client caches
+// the ID is then parsed in upnphttp.c using strtoll() which will stop at '_' and ignore the rest 
+#define COLUMNS "o.DETAIL_ID || '_' || strftime('%%s',d.DATE) , o.CLASS," \
                 " d.SIZE, d.TITLE, d.DURATION, d.BITRATE, d.SAMPLERATE, d.ARTIST," \
                 " d.ALBUM, d.GENRE, d.COMMENT, d.CHANNELS, d.TRACK, d.DATE, d.RESOLUTION," \
                 " d.THUMBNAIL, d.CREATOR, d.DLNA_PN, d.MIME, d.ALBUM_ART, d.ROTATION, d.DISC "


### PR DESCRIPTION
The timestamps are added using SQLite directly in the query. That creates object-IDs like 12_12312312 instead of just 12. Due to using strtoll() to parse the IDs it'll stop at the _ and the object-IDs will be read correctly. The side-effect is that DLNA Clients that request file- and artwork-urls will receive new URLs as soon as the files are rescanned (like when starting minidlna with -R). Otherwise clients would not pick up changed artwork unless their caches are flushed manually.